### PR TITLE
pass failures to header - required for junit reporter

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ exports.writeFile = function (opts) {
             return;
         }
         var outStream = fs.createWriteStream(opts.filePath);
-        outStream.write(exports.xmlEmitter.getHeader());
+        outStream.write(exports.xmlEmitter.getHeader(exports.out));
         exports.out.forEach(function (item) {
             outStream.write(exports.xmlEmitter.formatContent(item));
         });


### PR DESCRIPTION
the junit reporter includes a count of failures in the header, so
pass the failures to getHeader() -- otherwise, the junit output
always lists total failures as "0".
