### PR TITLE
Added a globalPaths options to write global file paths to output

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ exports.writeFile = function (opts) {
     opts.filePath = opts.filePath || 'jshint.xml';
     opts.format = opts.format || 'checkstyle';
     opts.alwaysReport = opts.alwaysReport || false;
-    opts.relativePaths = opts.relativePaths || true;
+    opts.globalPaths = opts.globalPaths || false;
     exports.xmlEmitter = loadFormatter(opts.format);
     return function () {
         if (!opts.alwaysReport && !exports.out.length) {
@@ -69,7 +69,7 @@ exports.writeFile = function (opts) {
             var outStream = fs.createWriteStream(opts.filePath);
             outStream.write(exports.xmlEmitter.getHeader(exports.out));
             exports.out.forEach(function (item) {
-                outStream.write(exports.xmlEmitter.formatContent(item, opts.relativePaths));
+                outStream.write(exports.xmlEmitter.formatContent(item, opts.globalPaths));
             });
             outStream.write(exports.xmlEmitter.getFooter());
             reset();

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ exports.writeFile = function (opts) {
     opts.filePath = opts.filePath || 'jshint.xml';
     opts.format = opts.format || 'checkstyle';
     opts.alwaysReport = opts.alwaysReport || false;
+    opts.relativePaths = opts.relativePaths || true;
     exports.xmlEmitter = loadFormatter(opts.format);
     return function () {
         if (!opts.alwaysReport && !exports.out.length) {
@@ -68,7 +69,7 @@ exports.writeFile = function (opts) {
             var outStream = fs.createWriteStream(opts.filePath);
             outStream.write(exports.xmlEmitter.getHeader(exports.out));
             exports.out.forEach(function (item) {
-                outStream.write(exports.xmlEmitter.formatContent(item));
+                outStream.write(exports.xmlEmitter.formatContent(item, opts.relativePaths));
             });
             outStream.write(exports.xmlEmitter.getFooter());
             reset();

--- a/lib/checkstyle_emitter.js
+++ b/lib/checkstyle_emitter.js
@@ -19,15 +19,19 @@ exports.getFooter = function () {
     return '\n</checkstyle>\n';
 };
 
-exports.formatContent = function (results, relativePaths) {
+exports.formatContent = function (results, globalPaths) {
     var out = [],
         files = {},
         issue, verbose = false,
         fileName, i;
 
     results.forEach(function (result) {
-        if (relativePaths) {
+        if (!globalPaths) {
             result.file = result.file.replace(process.cwd() + '/', '');
+        } else {
+            if (result.file.charAt(0) !== '/') { // relative path
+                result.file = process.cwd() + '/' + result.file;
+            }
         }
         if (!files[result.file]) {
             files[result.file] = [];

--- a/lib/checkstyle_emitter.js
+++ b/lib/checkstyle_emitter.js
@@ -19,14 +19,16 @@ exports.getFooter = function () {
     return '\n</checkstyle>\n';
 };
 
-exports.formatContent = function (results) {
+exports.formatContent = function (results, relativePaths) {
     var out = [],
         files = {},
         issue, verbose = false,
         fileName, i;
 
     results.forEach(function (result) {
-        result.file = result.file.replace(process.cwd() + '/', '');
+        if (relativePaths) {
+            result.file = result.file.replace(process.cwd() + '/', '');
+        }
         if (!files[result.file]) {
             files[result.file] = [];
         }

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "gulp-jshint": "*"
   },
   "devDependencies": {
-    "gulp-jshint": "1.9.0",
-    "mocha": "2.1.0",
-    "should": "4.6.3"
+    "gulp-jshint": "^2.0.4",
+    "mocha": "^3.4.2",
+    "should": "^11.2.1"
   },
   "dependencies": {
     "mkdirp": "0.5.1"


### PR DESCRIPTION
Since phpcs or scss lint write full/global paths as file names to the checkstyle output xml, I needed a way to have global paths in the xml from jshint too. Here is a patch that adds a globalPaths option, and keeps the current behavior as default.
