### PR TITLE
Use JSHint's severity levels in checkstyle XML output

### DIFF
--- a/lib/checkstyle_emitter.js
+++ b/lib/checkstyle_emitter.js
@@ -8,6 +8,12 @@ function escapeAttrValue(attrValue) {
         .replace(/>/g, '&gt;');
 }
 
+var severityLevels = {
+    'W': 'warning',
+    'E': 'error',
+    'I': 'info'
+};
+
 exports.getHeader = function () {
     var out = [];
     out.push('<?xml version="1.0" encoding="utf-8"?>');
@@ -31,7 +37,7 @@ exports.formatContent = function (results) {
             files[result.file] = [];
         }
         files[result.file].push({
-            severity: 'error',
+            severity: severityLevels.hasOwnProperty(result.error.code[0]) ? severityLevels[result.error.code[0]] : 'error',
             line: result.error.line,
             column: result.error.character,
             message: result.error.reason + ((verbose) ?

--- a/test/checkstyle/fixtures/errors.json
+++ b/test/checkstyle/fixtures/errors.json
@@ -107,5 +107,33 @@
             "a": "a",
             "reason": "'a' is defined but never used."
         }
+    },
+    {
+        "file": "dummy.js",
+        "error": {
+            "id": "(error)",
+            "raw": "const '{a}' has already been declared.",
+            "code": "E011",
+            "evidence": "const a = 1; const a = 2;",
+            "line": 10,
+            "character": 1,
+            "scope": "(main)",
+            "a": "a",
+            "reason": "const 'a' has already been declared."
+        }
+    },
+    {
+        "file": "dummy.js",
+        "error": {
+            "id": "(error)",
+            "raw": "ES5 option is now set per default",
+            "code": "I003",
+            "evidence": "/*jshint es5: true */",
+            "line": 11,
+            "character": 1,
+            "scope": "(main)",
+            "a": "a",
+            "reason": "ES5 option is now set per default"
+        }
     }
 ]

--- a/test/checkstyle/fixtures/mock.xml
+++ b/test/checkstyle/fixtures/mock.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <checkstyle version="4.3">
 	<file name="dummy.js">
-		<error line="1" column="13" severity="error" message="Strings must use singlequote." source="jshint.W109" />
-		<error line="1" column="1" severity="error" message="Missing semicolon." source="jshint.W033" />
-		<error line="3" column="9" severity="error" message="Missing name in function declaration." source="jshint.W025" />
-		<error line="9" column="1" severity="error" message="'c' is not defined." source="jshint.W117" />
-		<error line="3" column="1" severity="error" message="'undefined' is defined but never used." source="jshint.W098" />
-		<error line="7" column="5" severity="error" message="'a' is defined but never used." source="jshint.W098" />
-		<error line="7" column="8" severity="error" message="'b' is defined but never used." source="jshint.W098" />
-		<error line="3" column="10" severity="error" message="'a' is defined but never used." source="jshint.W098" />
+		<error line="1" column="13" severity="warning" message="Strings must use singlequote." source="jshint.W109" />
+		<error line="1" column="1" severity="warning" message="Missing semicolon." source="jshint.W033" />
+		<error line="3" column="9" severity="warning" message="Missing name in function declaration." source="jshint.W025" />
+		<error line="9" column="1" severity="warning" message="'c' is not defined." source="jshint.W117" />
+		<error line="3" column="1" severity="warning" message="'undefined' is defined but never used." source="jshint.W098" />
+		<error line="7" column="5" severity="warning" message="'a' is defined but never used." source="jshint.W098" />
+		<error line="7" column="8" severity="warning" message="'b' is defined but never used." source="jshint.W098" />
+		<error line="3" column="10" severity="warning" message="'a' is defined but never used." source="jshint.W098" />
+		<error line="10" column="1" severity="error" message="const 'a' has already been declared." source="jshint.E011" />
+		<error line="11" column="1" severity="info" message="ES5 option is now set per default" source="jshint.I003" />
 	</file>
 </checkstyle>


### PR DESCRIPTION
JSHint uses severity levels in its reporting. Three severity levels are used: `error`, `warning` and `info`. Errors reported in checkstyle XMLs also have a severity property. Checkstyle supports four severities: `error`, `warning`, `info` and `ignore`.

Currently, gulp-jshint-xml-file-reporter's checkstyle reporter assigns the `error` severity to each issue JSHint finds, regardless of the severity of the actual issue as reported by JSHint itself. This isn't very useful, and prevents advanced use cases of the reporter in combination with a CI solution. This PR solves this.

Tests have been updated and verified, as well.
